### PR TITLE
Fix sed not modifying image version

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -58,9 +58,13 @@ jobs:
           SERVICE: ${{ env.SERVICE_NAME }}
           VERSION: ${{ env.RELEASE_VERSION }}
         run: |
+          # go to directory with configuration
           cd "rubicon/prod/services/$SERVICE"
-          export SED_PREPARED=$(echo $IMAGE  | awk '{ gsub("/", "\\/", $1); print $1 }')
+          # escape literals for the sed and set output with GCR
+          export SED_PREPARED=$(echo $IMAGE  | awk '{ gsub("/", "\\/", $1); print "eu.gcr.io\\/"$1 }')
+          # update final yaml
           sed -i".bak" "s/image: $SED_PREPARED.*/image: $SED_PREPARED:$VERSION/g" "$SERVICE.yaml"
+          # delete bakup file
           rm "$SERVICE.yaml.bak"
 
       # Setup gcloud CLI


### PR DESCRIPTION
As I was developing this pipeline against poll bot and poll bot is hosted (currently, will be changed) in the docker hub and not GCR, I didn't notice that Roman has slightly different image syntax in the Rubicon.

Roman:
```yaml
eu.gcr.io/wire-bot/roman:1.5.0
```
Poll bot syntax:
```yaml
wire-bot/roman:1.5.0
```

As a result, `sed` didn't replace the version because it was expecting `image: wire-bot/roman`, this should be fixed now as `awk` now returns image with gcr prefix:

`print $1`  was changed to `print "eu.gcr.io\\/"$1`