### PR TITLE
Make Roman compatible with Dagobah cluster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.idea
+target
+Dockerfile
+docker-compose.yml
+README.md
+roman.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,57 +2,31 @@ FROM maven:3.6.3-jdk-8-slim AS build
 LABEL description="Wire Roman"
 LABEL project="wire-bots:roman"
 
-WORKDIR /src
-
-# download wait-for script
-RUN curl https://raw.githubusercontent.com/LukasForst/wait-for/master/wait-for > wait-for
-RUN chmod +x wait-for
-
-# ------------------ App specific ------------------
 WORKDIR /app
 
-# install maven dependencies
 COPY pom.xml ./
+
 RUN mvn verify --fail-never -U
 
-# build application
 COPY . ./
+
 RUN mvn -Dmaven.test.skip=true package
 
-# runtime
 FROM dejankovacevic/bots.runtime:2.10.3
 
-RUN apt install netcat -y
+COPY --from=build-env /app/target/roman.jar /opt/roman/
+# COPY target/roman.jar   /opt/roman/roman.jar
 
-COPY --from=build /app/target/roman.jar /opt/roman/
+COPY roman.yaml         /etc/roman/
 
-# create configuration
-COPY roman.yaml /etc/roman/
-
-# ------------------ Wire common ------------------
-# set APP_DIR - where is the entrypoint
-ENV APP_DIR=/opt/roman
-# copy wait for script to root for running in kubernetes
-COPY --from=build /src/wait-for /wait-for
 # create version file
 ARG release_version=development
-ENV RELEASE_FILE_PATH=$APP_DIR/release.txt
-RUN echo $release_version > $RELEASE_FILE_PATH
-# enable json logging
-ENV JSON_LOGGING=true
-# move to runtime directory
-WORKDIR $APP_DIR
-# /------------------ Wire common -----------------
+ENV RELEASE_FILE_PATH=/opt/roman/release.txt
+RUN echo $release_version > /opt/roman/release.txt
+
+WORKDIR /opt/roman
 
 EXPOSE  8080 8081 8082
 
-# create entrypoint
-RUN echo "\
-cd $APP_DIR && \
-java    -javaagent:/opt/wire/lib/jmx_prometheus_javaagent.jar=8082:/opt/wire/lib/metrics.yaml \
-        -jar roman.jar \
-        server /etc/roman/roman.yaml"\
->> /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["java", "-javaagent:/opt/wire/lib/jmx_prometheus_javaagent.jar=8082:/opt/wire/lib/metrics.yaml", "-jar", "roman.jar", "server", "/etc/roman/roman.yaml"]
 
-ENTRYPOINT /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.test.skip=true package
 
 FROM dejankovacevic/bots.runtime:2.10.3
 
-COPY --from=build-env /app/target/roman.jar /opt/roman/
+COPY --from=build /app/target/roman.jar /opt/roman/
 # COPY target/roman.jar   /opt/roman/roman.jar
 
 COPY roman.yaml         /etc/roman/
@@ -23,6 +23,7 @@ COPY roman.yaml         /etc/roman/
 ARG release_version=development
 ENV RELEASE_FILE_PATH=/opt/roman/release.txt
 RUN echo $release_version > /opt/roman/release.txt
+ENV APPENDER_TYPE=json-console
 
 WORKDIR /opt/roman
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ COPY roman.yaml         /etc/roman/
 ARG release_version=development
 ENV RELEASE_FILE_PATH=/opt/roman/release.txt
 RUN echo $release_version > /opt/roman/release.txt
-ENV APPENDER_TYPE=json-console
+# TODO - uncomment this when migration to JSON logging is finalized
+#ENV APPENDER_TYPE=json-console
 
 WORKDIR /opt/roman
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,55 @@
-FROM docker.io/maven AS build-env
+FROM maven:3.6.3-jdk-8-slim AS build
+LABEL description="Wire Roman"
+LABEL project="wire-bots:roman"
 
+WORKDIR /src
+
+# download wait-for script
+RUN curl https://raw.githubusercontent.com/LukasForst/wait-for/master/wait-for > wait-for
+RUN chmod +x wait-for
+
+# ------------------ App specific ------------------
 WORKDIR /app
 
+# install maven dependencies
 COPY pom.xml ./
-
 RUN mvn verify --fail-never -U
 
+# build application
 COPY . ./
-
 RUN mvn -Dmaven.test.skip=true package
 
+# runtime
 FROM dejankovacevic/bots.runtime:2.10.3
 
-COPY --from=build-env /app/target/roman.jar /opt/roman/
-# COPY target/roman.jar   /opt/roman/roman.jar
+COPY --from=build /app/target/roman.jar /opt/roman/
 
-COPY roman.yaml         /etc/roman/
+# create configuration
+COPY roman.yaml /etc/roman/
 
+# ------------------ Wire common ------------------
+# set APP_DIR - where is the entrypoint
+ENV APP_DIR=/opt/roman
+# copy wait for script to root for running in kubernetes
+COPY --from=build /src/wait-for /wait-for
 # create version file
 ARG release_version=development
-ENV RELEASE_FILE_PATH=/opt/roman/release.txt
-RUN echo $release_version > /opt/roman/release.txt
-
-WORKDIR /opt/roman
+ENV RELEASE_FILE_PATH=$APP_DIR/release.txt
+RUN echo $release_version > $RELEASE_FILE_PATH
+# enable json logging
+ENV JSON_LOGGING=true
+# move to runtime directory
+WORKDIR $APP_DIR
+# /------------------ Wire common -----------------
 
 EXPOSE  8080 8081 8082
 
-ENTRYPOINT ["java", "-javaagent:/opt/wire/lib/jmx_prometheus_javaagent.jar=8082:/opt/wire/lib/metrics.yaml", "-jar", "roman.jar", "server", "/etc/roman/roman.yaml"]
+# create entrypoint
+RUN echo '\
+java    -javaagent:/opt/wire/lib/jmx_prometheus_javaagent.jar=8082:/opt/wire/lib/metrics.yaml \
+        -jar roman.jar \
+        server /etc/roman/roman.yaml'\
+>> entrypoint.sh
+RUN chmod +x entrypoint.sh
 
+ENTRYPOINT $APP_DIR/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN mvn -Dmaven.test.skip=true package
 # runtime
 FROM dejankovacevic/bots.runtime:2.10.3
 
+RUN apt install netcat -y
+
 COPY --from=build /app/target/roman.jar /opt/roman/
 
 # create configuration
@@ -45,11 +47,12 @@ WORKDIR $APP_DIR
 EXPOSE  8080 8081 8082
 
 # create entrypoint
-RUN echo '\
+RUN echo "\
+cd $APP_DIR && \
 java    -javaagent:/opt/wire/lib/jmx_prometheus_javaagent.jar=8082:/opt/wire/lib/metrics.yaml \
         -jar roman.jar \
-        server /etc/roman/roman.yaml'\
->> entrypoint.sh
-RUN chmod +x entrypoint.sh
+        server /etc/roman/roman.yaml"\
+>> /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-ENTRYPOINT $APP_DIR/entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - DB_USER=roman
       - DB_PASSWORD=roman
       # randomly generated for local testing
-      - APP_KEY=0fb0f7f1-99aa-456c-a2bd-9e1132d0e9f4
+      - APP_KEY=b53181dd-6400-4960-8988-f775545588ff-0949f503-421e-4588-a2c5-f64fd9c180fd
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.7'
+services:
+  roman:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - release_version=docker-compose
+    image: eu.gcr.io/wire-bot/roman
+    ports:
+      - 8080:8080
+      - 8081:8081
+      - 8082:8082
+    environment:
+      - DB_URL=jdbc:postgresql://db:5432/roman
+      - DB_USER=roman
+      - DB_PASSWORD=roman
+      # randomly generated for local testing
+      - APP_KEY=0fb0f7f1-99aa-456c-a2bd-9e1132d0e9f4
+    depends_on:
+      - db
+
+  db:
+    image: postgres:12.2
+    # just for local development
+    environment:
+      - POSTGRES_USER=roman
+      - POSTGRES_PASSWORD=roman
+      - POSTGRES_DB=roman
+    ports:
+      - 5432:5432
+    volumes:
+      - roman-db:/var/lib/postgresql/data/
+
+volumes:
+  roman-db:

--- a/roman.yaml
+++ b/roman.yaml
@@ -1,12 +1,14 @@
 server:
   requestLog:
     appenders:
-      - type: console
+      - type: ${APPENDER_TYPE:-console}
         filterFactories:
           - type: status-filter-factory
 
 logging:
   level: INFO
+  appenders:
+    - type: ${APPENDER_TYPE:-console}
   loggers:
     "com.wire.bots.logger": ${LOG_LEVEL:-INFO}
 


### PR DESCRIPTION
* fixed dockerignore - changes in docker-compose no longer trigger whole build
* add labels to docker images 
* add env variable to enable/disable JSON logging - by default disabled even in docker image to keep it compatible by default with annayotto k8s cluster
* add docker-compose.yml for local testing - you don't need to have Postgre installed locally now
