### PR TITLE
BroadcastV2Resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     </repositories>
 
     <properties>
-        <lithium.version>3.0.13</lithium.version>
+        <lithium.version>3.0.14</lithium.version>
         <dropwizard.version>2.0.15</dropwizard.version>
         <maven.test.skip>true</maven.test.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/wire/bots/roman/Application.java
+++ b/src/main/java/com/wire/bots/roman/Application.java
@@ -103,6 +103,7 @@ public class Application extends Server<Config> {
         addResource(new ConversationResource(sender));
         addResource(new UsersResource(getRepo()));
         addResource(new BroadcastResource(jdbi, sender, executorService));
+        addResource(new BroadcastV2Resource(jdbi, sender, executorService));
         addResource(new MessagesResource());
 
         messageHandler.setSender(sender);

--- a/src/main/java/com/wire/bots/roman/MessageHandler.java
+++ b/src/main/java/com/wire/bots/roman/MessageHandler.java
@@ -139,6 +139,8 @@ public class MessageHandler extends MessageHandlerBase {
             message.mimeType = msg.getMimeType();
             message.conversationId = client.getConversationId();
 
+            message.meta = extractAssetMeta(msg);
+
             send(message);
         } catch (Exception e) {
             Logger.exception("onImage: %s", e, e.getMessage());
@@ -163,6 +165,8 @@ public class MessageHandler extends MessageHandlerBase {
             message.text = msg.getName();
             message.mimeType = msg.getMimeType();
             message.conversationId = client.getConversationId();
+
+            message.meta = extractAssetMeta(msg);
 
             send(message);
         } catch (Exception e) {
@@ -191,6 +195,8 @@ public class MessageHandler extends MessageHandlerBase {
             message.duration = msg.getDuration();
             message.levels = msg.getLevels();
             message.conversationId = client.getConversationId();
+
+            message.meta = extractAssetMeta(msg);
 
             send(message);
         } catch (Exception e) {
@@ -419,6 +425,15 @@ public class MessageHandler extends MessageHandlerBase {
             throw new RuntimeException("Unknown botId: " + botId.toString());
         MDCUtils.put("providerId", providerId);
         return providerId;
+    }
+
+    private AssetMeta extractAssetMeta(MessageAssetBase msg) {
+        AssetMeta meta = new AssetMeta();
+        meta.assetKey = msg.getAssetKey();
+        meta.assetToken = msg.getAssetToken();
+        meta.sha256 = Base64.getEncoder().encodeToString(msg.getSha256());
+        meta.otrKey = Base64.getEncoder().encodeToString(msg.getOtrKey());
+        return meta;
     }
 
     public void setSender(Sender sender) {

--- a/src/main/java/com/wire/bots/roman/model/AssetMeta.java
+++ b/src/main/java/com/wire/bots/roman/model/AssetMeta.java
@@ -1,0 +1,24 @@
+package com.wire.bots.roman.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AssetMeta {
+    @JsonProperty
+    @NotNull
+    public String assetKey;
+
+    @JsonProperty
+    public String assetToken;
+
+    @JsonProperty
+    @NotNull
+    public String sha256;
+
+    @JsonProperty
+    @NotNull
+    public String otrKey;
+}

--- a/src/main/java/com/wire/bots/roman/model/BroadcastMessage.java
+++ b/src/main/java/com/wire/bots/roman/model/BroadcastMessage.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BroadcastMessage {
@@ -36,7 +35,4 @@ public class BroadcastMessage {
 
     @JsonProperty
     public String otrKey;
-
-    @JsonProperty
-    public ArrayList<Mention> mentions;
 }

--- a/src/main/java/com/wire/bots/roman/model/BroadcastMessage.java
+++ b/src/main/java/com/wire/bots/roman/model/BroadcastMessage.java
@@ -1,0 +1,42 @@
+package com.wire.bots.roman.model;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BroadcastMessage {
+    @JsonProperty
+    @NotNull
+    public String mimeType;
+
+    @JsonProperty
+    public String filename;
+
+    @JsonProperty
+    public Long duration;
+
+    @JsonProperty
+    public int size;
+
+    @JsonProperty
+    public byte[] levels;
+
+    @JsonProperty
+    public String assetKey;
+
+    @JsonProperty
+    public String assetToken;
+
+    @JsonProperty
+    public String sha256;
+
+    @JsonProperty
+    public String otrKey;
+
+    @JsonProperty
+    public ArrayList<Mention> mentions;
+}

--- a/src/main/java/com/wire/bots/roman/model/OutgoingMessage.java
+++ b/src/main/java/com/wire/bots/roman/model/OutgoingMessage.java
@@ -35,6 +35,8 @@ public class OutgoingMessage {
     public ArrayList<Mention> mentions = new ArrayList<>();
     public Call call;
 
+    public AssetMeta meta;
+
     public void addMention(UUID userId, int offset, int len) {
         Mention mention = new Mention();
         mention.userId = userId;

--- a/src/main/java/com/wire/bots/roman/resources/BroadcastV2Resource.java
+++ b/src/main/java/com/wire/bots/roman/resources/BroadcastV2Resource.java
@@ -1,0 +1,209 @@
+package com.wire.bots.roman.resources;
+
+import com.codahale.metrics.annotation.Metered;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wire.bots.roman.DAO.BotsDAO;
+import com.wire.bots.roman.DAO.BroadcastDAO;
+import com.wire.bots.roman.Sender;
+import com.wire.bots.roman.filters.ServiceTokenAuthorization;
+import com.wire.bots.roman.model.BroadcastMessage;
+import com.wire.bots.roman.model.Report;
+import com.wire.lithium.server.monitoring.MDCUtils;
+import com.wire.xenon.assets.*;
+import com.wire.xenon.backend.models.ErrorMessage;
+import com.wire.xenon.tools.Logger;
+import io.swagger.annotations.*;
+import org.jdbi.v3.core.Jdbi;
+
+import javax.annotation.Nullable;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.*;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.logging.Level;
+
+import static com.wire.bots.roman.Const.APP_KEY;
+import static com.wire.bots.roman.Const.PROVIDER_ID;
+
+@Api
+@Path("/broadcast/v2")
+@Produces(MediaType.APPLICATION_JSON)
+public class BroadcastV2Resource {
+    private final Sender sender;
+    private final BotsDAO botsDAO;
+    private final BroadcastDAO broadcastDAO;
+    private final ExecutorService broadcast;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public BroadcastV2Resource(Jdbi jdbi, Sender sender, ExecutorService broadcast) {
+        this.sender = sender;
+        this.broadcast = broadcast;
+
+        botsDAO = jdbi.onDemand(BotsDAO.class);
+        broadcastDAO = jdbi.onDemand(BroadcastDAO.class);
+    }
+
+    @POST
+    @ApiOperation(value = "Broadcast message on Wire", authorizations = {@Authorization(value = "Bearer")})
+    @ApiResponses(value = {@ApiResponse(code = 401, message = "Not authenticated", response = Report.class)})
+    @Metered
+    @ServiceTokenAuthorization
+    public Response post(@Context ContainerRequestContext context,
+                         @ApiParam @HeaderParam(APP_KEY) String token,
+                         @ApiParam @NotNull @Valid BroadcastMessage message) {
+        try {
+            trace(message);
+
+            final UUID providerId = (UUID) context.getProperty(PROVIDER_ID);
+
+            List<UUID> botIds = botsDAO.getBotIds(providerId);
+
+            final UUID broadcastId = UUID.randomUUID();
+
+            MDCUtils.put("broadcastId", broadcastId);
+            Logger.info("BroadcastV2Resource.post: `%s`", message.mimeType);
+
+            for (UUID botId : botIds) {
+                broadcast.submit(() -> {
+                    if (message.mimeType.startsWith("audio")) {
+                        sendAudio(message, providerId, broadcastId, botId);
+                    } else if (message.mimeType.startsWith("image")) {
+                        sendPicture(message, providerId, broadcastId, botId);
+                    } else {
+                        sendFile(message, providerId, broadcastId, botId);
+                    }
+                });
+            }
+
+            Report ret = new Report();
+            ret.broadcastId = broadcastId;
+            ret.report = broadcastDAO.report(broadcastId);
+
+            return Response.
+                    ok(ret).
+                    build();
+        } catch (Exception e) {
+            Logger.exception("BroadcastV2Resource.post", e);
+            return Response
+                    .ok(new ErrorMessage(e.getMessage()))
+                    .status(500)
+                    .build();
+        }
+    }
+
+    private void sendAudio(BroadcastMessage message, UUID providerId, UUID broadcastId, UUID botId) {
+        final AudioPreview preview = new AudioPreview(
+                message.filename,
+                message.mimeType,
+                message.duration,
+                message.levels,
+                message.size);
+
+        final AudioAsset audioAsset = new AudioAsset(preview.getMessageId(), message.mimeType);
+        audioAsset.setAssetKey(message.assetKey);
+        audioAsset.setAssetToken(message.assetToken);
+        audioAsset.setSha256(Base64.getDecoder().decode(message.sha256));
+        audioAsset.setOtrKey(Base64.getDecoder().decode(message.otrKey));
+
+        sendAsset(providerId, broadcastId, preview, audioAsset, botId);
+    }
+
+    private void sendFile(BroadcastMessage message, UUID providerId, UUID broadcastId, UUID botId) {
+        final FileAssetPreview preview = new FileAssetPreview(
+                message.filename,
+                message.mimeType,
+                message.size,
+                UUID.randomUUID());
+
+        final FileAsset audioAsset = new FileAsset(message.assetKey,
+                message.assetToken,
+                Base64.getDecoder().decode(message.sha256),
+                Base64.getDecoder().decode(message.otrKey),
+                preview.getMessageId());
+
+        sendAsset(providerId, broadcastId, preview, audioAsset, botId);
+    }
+
+    private void sendPicture(BroadcastMessage message, UUID providerId, UUID broadcastId, UUID botId) {
+        final Picture picture = new Picture(UUID.randomUUID(), message.mimeType);
+        picture.setAssetKey(message.assetKey);
+        picture.setAssetToken(message.assetToken);
+        picture.setSha256(Base64.getDecoder().decode(message.sha256));
+        picture.setOtrKey(Base64.getDecoder().decode(message.otrKey));
+
+        sendAsset(providerId, broadcastId, null, picture, botId);
+    }
+
+    @GET
+    @ApiOperation(value = "Get latest broadcast report", authorizations = {@Authorization(value = "Bearer")})
+    @ApiResponses(value = {@ApiResponse(code = 404, message = "Unknown broadcastId", response = Report.class)})
+    @Metered
+    @ServiceTokenAuthorization
+    public Response get(@Context ContainerRequestContext context,
+                        @ApiParam @HeaderParam(APP_KEY) String token,
+                        @ApiParam @QueryParam("id") UUID broadcastId) {
+        try {
+            final UUID providerId = (UUID) context.getProperty(PROVIDER_ID);
+
+            if (broadcastId == null) {
+                broadcastId = broadcastDAO.getBroadcastId(providerId);
+            }
+
+            if (broadcastId == null) {
+                return Response.
+                        status(404).
+                        build();
+            }
+
+            MDCUtils.put("broadcastId", broadcastId);
+            Logger.info("BroadcastV2Resource.get: broadcast: %s", broadcastId);
+
+            Report ret = new Report();
+            ret.broadcastId = broadcastId;
+            ret.report = broadcastDAO.report(broadcastId);
+
+            return Response.
+                    ok(ret).
+                    build();
+        } catch (Exception e) {
+            Logger.exception("BroadcastV2Resource.get", e);
+            return Response
+                    .ok(new ErrorMessage(e.getMessage()))
+                    .status(500)
+                    .build();
+        }
+    }
+
+    private void persist(UUID providerId, UUID broadcastId, UUID botId, UUID messageId) {
+        broadcastDAO.insert(broadcastId, botId, providerId, messageId, BroadcastDAO.Type.SENT.ordinal());
+    }
+
+    private void sendAsset(UUID providerId, UUID broadcastId, @Nullable IGeneric preview, AssetBase audioAsset, UUID botId) {
+        try {
+            if (preview != null) {
+                sender.send(preview, botId);
+            }
+
+            final UUID messageId = sender.send(audioAsset, botId);
+            if (messageId != null) {
+                persist(providerId, broadcastId, botId, messageId);
+            }
+        } catch (Exception e) {
+            Logger.exception("Broadcast send", e);
+        }
+    }
+
+    private void trace(BroadcastMessage message) throws JsonProcessingException {
+        if (Logger.getLevel() == Level.FINE) {
+            Logger.debug(objectMapper.writeValueAsString(message));
+        }
+    }
+}

--- a/src/main/java/com/wire/bots/roman/resources/BroadcastV2Resource.java
+++ b/src/main/java/com/wire/bots/roman/resources/BroadcastV2Resource.java
@@ -186,13 +186,13 @@ public class BroadcastV2Resource {
         broadcastDAO.insert(broadcastId, botId, providerId, messageId, BroadcastDAO.Type.SENT.ordinal());
     }
 
-    private void sendAsset(UUID providerId, UUID broadcastId, @Nullable IGeneric preview, AssetBase audioAsset, UUID botId) {
+    private void sendAsset(UUID providerId, UUID broadcastId, @Nullable IGeneric preview, AssetBase asset, UUID botId) {
         try {
             if (preview != null) {
                 sender.send(preview, botId);
             }
 
-            final UUID messageId = sender.send(audioAsset, botId);
+            final UUID messageId = sender.send(asset, botId);
             if (messageId != null) {
                 persist(providerId, broadcastId, botId, messageId);
             }

--- a/src/test/java/com/wire/bots/roman/integrations/IncomingBroadcastV2MessageTest.java
+++ b/src/test/java/com/wire/bots/roman/integrations/IncomingBroadcastV2MessageTest.java
@@ -1,0 +1,150 @@
+package com.wire.bots.roman.integrations;
+
+import com.wire.bots.roman.Application;
+import com.wire.bots.roman.Const;
+import com.wire.bots.roman.DAO.ProvidersDAO;
+import com.wire.bots.roman.Tools;
+import com.wire.bots.roman.model.BroadcastMessage;
+import com.wire.bots.roman.model.Config;
+import com.wire.bots.roman.model.Report;
+import com.wire.lithium.models.NewBotResponseModel;
+import com.wire.xenon.backend.models.Conversation;
+import com.wire.xenon.backend.models.NewBot;
+import com.wire.xenon.backend.models.User;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.DropwizardTestSupport;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IncomingBroadcastV2MessageTest {
+    private static final String BOT_CLIENT_DUMMY = "bot_client_dummy";
+    private static final DropwizardTestSupport<Config> SUPPORT = new DropwizardTestSupport<>(
+            Application.class, "roman.yaml",
+            ConfigOverride.config("key", "TcZA2Kq4GaOcIbQuOvasrw34321cZAfLW4Ga54fsds43hUuOdcdm42"),
+            ConfigOverride.config("apiHost", "http://localhost:8090"));
+    private Client client;
+    private Jdbi jdbi;
+
+    @Before
+    public void beforeClass() throws Exception {
+        SUPPORT.before();
+        Application app = SUPPORT.getApplication();
+        client = app.getClient();
+        jdbi = app.getJdbi();
+    }
+
+    @After
+    public void afterClass() {
+        SUPPORT.after();
+    }
+
+    @Test
+    public void broadcastTest() throws IOException, InterruptedException {
+        final Random random = new Random();
+        final UUID botId = UUID.randomUUID();
+        final UUID userId = UUID.randomUUID();
+        final UUID convId = UUID.randomUUID();
+        final UUID providerId = UUID.randomUUID();
+        final String serviceAuth = Tools.generateToken(providerId);
+
+        final String email = String.format("%s@email.com", serviceAuth);
+
+        // Create some fake provider and service
+        ProvidersDAO providersDAO = jdbi.onDemand(ProvidersDAO.class);
+        providersDAO.insert("Test Provider", providerId, email, "hash", "password");
+        providersDAO.update(providerId, "http://localhost:8080/messages", serviceAuth, UUID.randomUUID(), "Test Service");
+
+        // Test Bot added into conv. BE calls POST /bots with NewBot object
+        NewBotResponseModel newBotResponseModel = newBotFromBE(botId, userId, convId, serviceAuth);
+        assertThat(newBotResponseModel.lastPreKey).isNotNull();
+        assertThat(newBotResponseModel.preKeys).isNotNull();
+
+        BroadcastMessage audio = new BroadcastMessage();
+        audio.mimeType = "audio/x-m4a";
+        audio.filename = "test.m4a";
+        audio.duration = 27000L;
+        audio.levels = new byte[100];
+        audio.size = 1024 * 1024 * 4;
+        random.nextBytes(audio.levels);
+
+        audio.assetKey = UUID.randomUUID().toString();
+        audio.assetToken = UUID.randomUUID().toString();
+        final byte[] sha256 = new byte[256];
+        random.nextBytes(sha256);
+        final byte[] otrKey = new byte[32];
+        random.nextBytes(otrKey);
+
+        audio.sha256 = Base64.getEncoder().encodeToString(sha256);
+        audio.otrKey = Base64.getEncoder().encodeToString(otrKey);
+
+        Response res = post(serviceAuth, audio);
+        assertThat(res.getStatus()).isEqualTo(200);
+
+        Thread.sleep(5000);
+
+        res = get(serviceAuth);
+        assertThat(res.getStatus()).isEqualTo(200);
+
+        final Report report = res.readEntity(Report.class);
+    }
+
+    private Response post(String serviceAuth, BroadcastMessage msg) {
+        return client
+                .target("http://localhost:" + SUPPORT.getLocalPort())
+                .path("broadcast/v2")
+                .request()
+                .header(Const.APP_KEY, serviceAuth)
+                .post(Entity.entity(msg, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    private Response get(String serviceAuth) {
+        return client
+                .target("http://localhost:" + SUPPORT.getLocalPort())
+                .path("broadcast/v2")
+                .request()
+                .header(Const.APP_KEY, serviceAuth)
+                .get();
+    }
+
+    private NewBotResponseModel newBotFromBE(UUID botId, UUID userId, UUID convId, String serviceAuth) {
+        NewBot newBot = new NewBot();
+        newBot.id = botId;
+        newBot.locale = "en";
+        newBot.token = "token_dummy";
+        newBot.client = BOT_CLIENT_DUMMY;
+        newBot.origin = new User();
+        newBot.origin.id = userId;
+        newBot.origin.name = "user_name";
+        newBot.origin.handle = "user_handle";
+        newBot.conversation = new Conversation();
+        newBot.conversation.id = convId;
+        newBot.conversation.name = "conv_name";
+        newBot.conversation.creator = userId;
+        newBot.conversation.members = new ArrayList<>();
+
+        Response res = client
+                .target("http://localhost:" + SUPPORT.getLocalPort())
+                .path("bots")
+                .request()
+                .header("Authorization", "Bearer " + serviceAuth)
+                .post(Entity.entity(newBot, MediaType.APPLICATION_JSON_TYPE));
+
+        assertThat(res.getStatus()).isEqualTo(201);
+
+        return res.readEntity(NewBotResponseModel.class);
+    }
+}


### PR DESCRIPTION
This is an experiment. The idea is to pass the asset metadata in IncomingMessage to the bot in order to allow the bot to just pass this meta to /broadcast/v2 endpoint in order to broadcast. Metadata is sufficient to broadcast the asset without ever downloading it.
This PR still does not solve the problem fully as Roman still downloads the asset in order to Base64 it pass it in JSON.
Bot will then download it implicitly, which is not needed.
This can be solved by configuring Roman NOT to send the full asset in JSON but to leave up to client (bot service) to download the asset if needed.
/download endpoint would be needed