### PR TITLE
Fix link to Swagger

### DIFF
--- a/frontend/src/app/pages/home/components/Header.tsx
+++ b/frontend/src/app/pages/home/components/Header.tsx
@@ -8,7 +8,7 @@ export default function Header() {
   const styles = useStyles();
   return (
     <div className={styles.header}>
-      <Button href={`${romanBasePath}/swagger`} target="_blank">Wire Roman Swagger</Button>
+      <Button href={`${romanBasePath}swagger`} target="_blank">Wire Roman Swagger</Button>
 
       <Button onClick={logout}>Logout - {user}</Button>
     </div>


### PR DESCRIPTION
# What's new in this PR?

### Issues

The link to Swagger from the bot admin webpage is not working 

### Causes (Optional)

The link is rendered with an extra "/" which causes:

```
HTTP ERROR 404 Not Found
URI:	//swagger
STATUS:	404
MESSAGE:	Not Found
SERVLET:	assets
```

### Solutions

Removed the "/" between the base url and the path
