### PR TITLE
fix: migrating ws to jakarta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR ./frontend
 RUN npm i
 RUN npm run build
 
-FROM maven:3-openjdk-11 AS build
+FROM maven:3-openjdk-17 AS build
 WORKDIR /app
 
 COPY backend/pom.xml ./
@@ -18,7 +18,7 @@ COPY backend/ ./
 
 RUN mvn -Dmaven.test.skip=true package
 
-FROM wirebot/runtime:1.3.0 AS runtime
+FROM --platform=linux/amd64 wirebot/runtime:1.4.0 AS runtime
 LABEL description="Wire Roman"
 LABEL project="wire-bots:roman"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY backend/ ./
 
 RUN mvn -Dmaven.test.skip=true package
 
-FROM --platform=linux/amd64 wirebot/runtime:1.4.0 AS runtime
+FROM wirebot/runtime:1.4.0 AS runtime
 LABEL description="Wire Roman"
 LABEL project="wire-bots:roman"
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,7 +32,8 @@
         <dropwizard.version>4.0.0</dropwizard.version>
         <jwt.version>0.11.5</jwt.version>
         <junit5.version>5.8.2</junit5.version>
-        <jetty.version>10.0.18</jetty.version>
+        <jetty.version>11.0.18</jetty.version>
+        <jakarta.version>2.1.1</jakarta.version>
     </properties>
 
     <dependencyManagement>
@@ -69,10 +70,21 @@
             <artifactId>dropwizard-configurable-assets-bundle</artifactId>
             <version>1.3.5</version>
         </dependency>
+        <!-- MIGRATION TO JAKARTA JETTY 11 -->
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>2.1.1</version>
+            <version>${jakarta.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <version>${jakarta.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-jakarta-server</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
 
         <dependency>
@@ -112,56 +124,6 @@
             <version>${jwt.version}</version>
             <scope>runtime</scope>
         </dependency>
-
-        <!-- todo, old jee implementation -->
-        <dependency>
-            <groupId>jakarta.websocket</groupId>
-            <artifactId>jakarta.websocket-api</artifactId>
-            <version>1.1.2</version>
-        </dependency>
-        <!-- To run javax.websocket in embedded server -->
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-javax-server</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jetty-api</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jetty-server</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>javax-websocket-server-impl</artifactId>
-            <version>9.4.51.v20230217</version>
-        </dependency>
-
-        <!--        MIGRATION TO JAKARTA EE 10-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.eclipse.jetty.ee10.websocket</groupId>-->
-        <!--            <artifactId>jetty-ee10-websocket-jetty-api</artifactId>-->
-        <!--            <version>12.0.0.beta0</version>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.eclipse.jetty.ee10.websocket</groupId>-->
-        <!--            <artifactId>jetty-ee10-websocket-jetty-server</artifactId>-->
-        <!--            <version>${jetty.version}</version>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.eclipse.jetty.ee10.websocket</groupId>-->
-        <!--            <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>-->
-        <!--            <version>${jetty.version}</version>-->
-        <!--        </dependency>-->
-        <!--        <dependency>-->
-        <!--            <groupId>org.eclipse.jetty.ee10</groupId>-->
-        <!--            <artifactId>jetty-ee10-servlet</artifactId>-->
-        <!--            <version>${jetty.version}</version>-->
-        <!--        </dependency>-->
 
         <!-- test dependencies-->
         <dependency>
@@ -213,8 +175,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,8 +21,8 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -32,6 +32,7 @@
         <dropwizard.version>4.0.0</dropwizard.version>
         <jwt.version>0.11.5</jwt.version>
         <junit5.version>5.8.2</junit5.version>
+        <jetty.version>10.0.18</jetty.version>
     </properties>
 
     <dependencyManagement>
@@ -60,6 +61,10 @@
             <artifactId>dropwizard-assets</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-servlets</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard-bundles</groupId>
             <artifactId>dropwizard-configurable-assets-bundle</artifactId>
             <version>1.3.5</version>
@@ -70,12 +75,6 @@
             <version>2.1.1</version>
         </dependency>
 
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>8.0</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>com.wire</groupId>
             <artifactId>lithium</artifactId>
@@ -114,12 +113,55 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!--TODO. replace with jakarta version?-->
+        <!-- todo, old jee implementation -->
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <!-- To run javax.websocket in embedded server -->
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-javax-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-jetty-api</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-jetty-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>javax-websocket-server-impl</artifactId>
-            <version>9.4.53.v20231009</version>
+            <version>9.4.51.v20230217</version>
         </dependency>
+
+        <!--        MIGRATION TO JAKARTA EE 10-->
+        <!--        <dependency>-->
+        <!--            <groupId>org.eclipse.jetty.ee10.websocket</groupId>-->
+        <!--            <artifactId>jetty-ee10-websocket-jetty-api</artifactId>-->
+        <!--            <version>12.0.0.beta0</version>-->
+        <!--        </dependency>-->
+        <!--        <dependency>-->
+        <!--            <groupId>org.eclipse.jetty.ee10.websocket</groupId>-->
+        <!--            <artifactId>jetty-ee10-websocket-jetty-server</artifactId>-->
+        <!--            <version>${jetty.version}</version>-->
+        <!--        </dependency>-->
+        <!--        <dependency>-->
+        <!--            <groupId>org.eclipse.jetty.ee10.websocket</groupId>-->
+        <!--            <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>-->
+        <!--            <version>${jetty.version}</version>-->
+        <!--        </dependency>-->
+        <!--        <dependency>-->
+        <!--            <groupId>org.eclipse.jetty.ee10</groupId>-->
+        <!--            <artifactId>jetty-ee10-servlet</artifactId>-->
+        <!--            <version>${jetty.version}</version>-->
+        <!--        </dependency>-->
 
         <!-- test dependencies-->
         <dependency>

--- a/backend/src/main/java/com/wire/bots/roman/MessageEncoder.java
+++ b/backend/src/main/java/com/wire/bots/roman/MessageEncoder.java
@@ -3,10 +3,10 @@ package com.wire.bots.roman;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wire.bots.roman.model.OutgoingMessage;
+import jakarta.websocket.EncodeException;
+import jakarta.websocket.Encoder;
+import jakarta.websocket.EndpointConfig;
 
-import javax.websocket.EncodeException;
-import javax.websocket.Encoder;
-import javax.websocket.EndpointConfig;
 
 public class MessageEncoder implements Encoder.Text<OutgoingMessage> {
 

--- a/backend/src/main/java/com/wire/bots/roman/WebSocket.java
+++ b/backend/src/main/java/com/wire/bots/roman/WebSocket.java
@@ -2,10 +2,10 @@ package com.wire.bots.roman;
 
 import com.wire.bots.roman.model.OutgoingMessage;
 import com.wire.xenon.tools.Logger;
+import jakarta.websocket.*;
+import jakarta.websocket.server.PathParam;
+import jakarta.websocket.server.ServerEndpoint;
 
-import javax.websocket.*;
-import javax.websocket.server.PathParam;
-import javax.websocket.server.ServerEndpoint;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;

--- a/backend/src/main/java/com/wire/bots/roman/WebSocket.java
+++ b/backend/src/main/java/com/wire/bots/roman/WebSocket.java
@@ -47,6 +47,6 @@ public class WebSocket {
 
     @OnError
     public void onError(Session session, Throwable throwable) {
-        Logger.exception(throwable,"%s error: %s", session.getId(), throwable.getMessage());
+        Logger.exception(throwable, "%s error: %s", session.getId(), throwable.getMessage());
     }
 }


### PR DESCRIPTION
# What's new in this PR?

### Issues

Roman does not starts

### Causes (Optional)

Broken dependencies in WS level, because of incompatible or pending to migrate from JEE to Jakarta + Jetty 11

### Solutions

Configure it

### Dependencies (Optional)

Migrated to java17, so also updated the version of the runtime to 1.4.0 since that image is based on JDK 17

### Testing

#### Test Coverage (Optional)

#### How to Test

Manually tested, build locally and run roman, with these new configurations.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
