### PR TITLE
fix: frontend config with new assetbundle aproach dropwizard4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN mvn verify --fail-never -U
 
 COPY backend/ ./
 
+# Copy frontend build to local resources classpath folder
+ENV FRONTEND_PATH=/app/src/main/resources/frontend
+COPY --from=frontend-build ./frontend/build $FRONTEND_PATH
+
 RUN mvn -Dmaven.test.skip=true package
 
 FROM wirebot/runtime:1.4.0 AS runtime
@@ -28,9 +32,6 @@ RUN apt-get update && apt-get upgrade -y
 # Copy backend
 COPY --from=build /app/target/roman.jar /opt/roman/backend/
 COPY backend/roman.yaml /etc/roman/
-# Copy frontend
-ENV FRONTEND_PATH=/opt/roman/frontend
-COPY --from=frontend-build ./frontend/build $FRONTEND_PATH
 
 # create version file
 ARG release_version=development

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -65,11 +65,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-servlets</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.dropwizard-bundles</groupId>
-            <artifactId>dropwizard-configurable-assets-bundle</artifactId>
-            <version>1.3.5</version>
-        </dependency>
         <!-- MIGRATION TO JAKARTA JETTY 11 -->
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/backend/roman.yaml
+++ b/backend/roman.yaml
@@ -34,13 +34,6 @@ swagger:
     - https
     - http
 
-assets:
-  mappings:
-    /assets: /
-  overrides:
-    # the default assumes you have build frontend by "npm run build"
-    /: ${FRONTEND_PATH:-../frontend/build}
-
 jerseyClient:
   timeout: 40s
   connectionTimeout: 40s

--- a/backend/src/main/java/com/wire/bots/roman/Application.java
+++ b/backend/src/main/java/com/wire/bots/roman/Application.java
@@ -18,23 +18,15 @@
 package com.wire.bots.roman;
 
 import com.wire.bots.roman.commands.UpdateCertCommand;
-import com.wire.bots.roman.filters.BackendAuthenticationFilter;
-import com.wire.bots.roman.filters.CspResponseFilter;
-import com.wire.bots.roman.filters.ProxyAuthenticationFilter;
-import com.wire.bots.roman.filters.ServiceAuthenticationFilter;
-import com.wire.bots.roman.filters.ServiceTokenAuthenticationFilter;
+import com.wire.bots.roman.filters.*;
 import com.wire.bots.roman.model.Config;
-import com.wire.bots.roman.resources.BroadcastResource;
-import com.wire.bots.roman.resources.ConversationResource;
-import com.wire.bots.roman.resources.MessagesResource;
-import com.wire.bots.roman.resources.ProviderResource;
-import com.wire.bots.roman.resources.ServiceResource;
-import com.wire.bots.roman.resources.UsersResource;
+import com.wire.bots.roman.resources.*;
 import com.wire.lithium.ClientRepo;
 import com.wire.lithium.Server;
 import com.wire.xenon.MessageHandlerBase;
 import com.wire.xenon.factories.CryptoFactory;
 import com.wire.xenon.factories.StorageFactory;
+import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
 import io.jsonwebtoken.security.Keys;
@@ -70,6 +62,7 @@ public class Application extends Server<Config> {
         instance = (Application) bootstrap.getApplication();
         bootstrap.addBundle(new WebsocketBundle(WebSocket.class));
         bootstrap.addCommand(new UpdateCertCommand());
+        bootstrap.addBundle(new AssetsBundle("/frontend", "/", "index.html"));
     }
 
     @Override

--- a/backend/src/main/java/com/wire/bots/roman/model/Config.java
+++ b/backend/src/main/java/com/wire/bots/roman/model/Config.java
@@ -21,14 +21,11 @@ package com.wire.bots.roman.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wire.lithium.Configuration;
-import io.dropwizard.bundles.assets.AssetsBundleConfiguration;
-import io.dropwizard.bundles.assets.AssetsConfiguration;
 import io.dropwizard.validation.ValidationMethod;
-
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
-public class Config extends Configuration implements AssetsBundleConfiguration {
+public class Config extends Configuration {
     @NotNull
     @JsonProperty
     public String key;
@@ -44,14 +41,6 @@ public class Config extends Configuration implements AssetsBundleConfiguration {
     @NotEmpty
     @JsonProperty
     public String romanPubKeyBase64;
-
-    @JsonProperty
-    public AssetsConfiguration assets;
-
-    @Override
-    public AssetsConfiguration getAssetsConfiguration() {
-        return assets;
-    }
 
     @ValidationMethod(message = "`romanPubKeyBase64` is not in a valid base64 format")
     @JsonIgnore


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Front end not available.

### Causes (Optional)

New `AssetBundle` config from dropwizard4

### Solutions

Copy the frontend build to local resources classpath, to use the new config.

### Testing

Manually tested

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
