### PR TITLE
chore: cancel concurrent builds to avoid multiple runs and only run last

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker-build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -2,11 +2,15 @@ name: Release Pipeline
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 env:
   DOCKER_IMAGE: wire-bot/roman
   SERVICE_NAME: roman
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -16,6 +16,10 @@ env:
 
   NAMESPACE: staging
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: Deploy to staging


### PR DESCRIPTION
# What's new in this PR?

### Issues

Multiple runs of deployments can run at the same time, wasting time on intermedius builds

### Causes (Optional)

Non-concurrent handling on gh action

### Solutions

Cancel concurrent runs, to just run the last one, allowing only to build and check relevant builds.
https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-and-the-default-behavior

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
