### PR TITLE
fix: request min known flyway version for compatibility with pg prod

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -34,6 +34,7 @@
         <junit5.version>5.8.2</junit5.version>
         <jetty.version>11.0.18</jetty.version>
         <jakarta.version>2.1.1</jakarta.version>
+        <!-- BEFORE UPGRADING! VERIFY RUNTIME PG VERSION COMPATIBILITY -->
         <flyway.version>7.15.0</flyway.version>
     </properties>
 
@@ -125,7 +126,6 @@
             <version>${jwt.version}</version>
             <scope>runtime</scope>
         </dependency>
-        <!-- BEFORE UPGRADING! VERIFY RUNTIME PG VERSION COMPATIBILITY -->
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -34,6 +34,7 @@
         <junit5.version>5.8.2</junit5.version>
         <jetty.version>11.0.18</jetty.version>
         <jakarta.version>2.1.1</jakarta.version>
+        <flyway.version>7.15.0</flyway.version>
     </properties>
 
     <dependencyManagement>
@@ -124,6 +125,13 @@
             <version>${jwt.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <!-- BEFORE UPGRADING! VERIFY RUNTIME PG VERSION COMPATIBILITY -->
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>${flyway.version}</version>
+        </dependency>
+
 
         <!-- test dependencies-->
         <dependency>


### PR DESCRIPTION
# What's new in this PR?

### Issues

Not starting in prod because of flyway jump in versions and pg older version available at prod.

### Causes (Optional)

Roman not starting in prod

### Solutions

Request latest 7.x version to maintain compatibility, we need to change later which min version is allowed (ie, version 8.x) or upgrading pg in prod.

Latest working was v7.8.2

![Screenshot 2023-12-11 at 14 03 37](https://github.com/wireapp/roman/assets/5806454/f98473f1-f322-4c9e-a97e-870573997e76)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
