### PR TITLE
feat: add conversationId on bot removed event

### DIFF
--- a/backend/src/main/java/com/wire/bots/roman/MessageHandler.java
+++ b/backend/src/main/java/com/wire/bots/roman/MessageHandler.java
@@ -381,6 +381,7 @@ public class MessageHandler extends MessageHandlerBase {
         OutgoingMessage message = new OutgoingMessage();
         message.botId = botId;
         message.type = "conversation.bot_removed";
+        message.conversationId = msg.conversation.id;
 
         if (!send(message))
             Logger.info("onBotRemoved: failed to deliver message");


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Missing information about which conversation the bot was removed from, making it not possible to clean up resources in a detailed manner, ie, removing data from the bot associated to the `conversationId`.

### Solutions

Adds `conversationId` information to the `onBotRemoved` event, so bots can react and perform a cleanup of their resources.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
